### PR TITLE
Revert "Fix compilation with OpenSSL >= 1.1.0"

### DIFF
--- a/lmc/src/crypto.cpp
+++ b/lmc/src/crypto.cpp
@@ -1,11 +1,11 @@
 ﻿/****************************************************************************
 **
 ** This file is part of LAN Messenger.
-**
+** 
 ** Copyright (c) 2010 - 2012 Qualia Digital Solutions.
-**
+** 
 ** Contact:  qualiatech@gmail.com
-**
+** 
 ** LAN Messenger is free software: you can redistribute it and/or modify
 ** it under the terms of the GNU General Public License as published by
 ** the Free Software Foundation, either version 3 of the License, or
@@ -62,7 +62,7 @@ QByteArray lmcCrypto::generateAES(QString* lpszUserId, QByteArray& pubKey) {
 	RSA* rsa = RSA_new();
 	BIO* bio = BIO_new_mem_buf(pemKey, pubKey.length());
 	PEM_read_bio_RSAPublicKey(bio, &rsa, NULL, NULL);
-
+	
 	int keyDataLen = 32;
 	unsigned char* keyData = (unsigned char*)malloc(keyDataLen);
 	RAND_bytes(keyData, keyDataLen);
@@ -74,10 +74,11 @@ QByteArray lmcCrypto::generateAES(QString* lpszUserId, QByteArray& pubKey) {
 	keyLen = EVP_BytesToKey(EVP_aes_256_cbc(), EVP_sha1(), NULL, keyData, keyDataLen, rounds, keyIv, keyIv + keyLen);
 
 	EVP_CIPHER_CTX ectx, dctx;
-	EVP_EncryptInit_ex(ectx.ptr(), EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
+	EVP_CIPHER_CTX_init(&ectx);
+	EVP_EncryptInit_ex(&ectx, EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
 	encryptMap.insert(*lpszUserId, ectx);
-	EVP_CIPHER_CTX_init(dctx.ptr());
-	EVP_DecryptInit_ex(dctx.ptr(), EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
+	EVP_CIPHER_CTX_init(&dctx);
+	EVP_DecryptInit_ex(&dctx, EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
 	decryptMap.insert(*lpszUserId, dctx);
 
 	unsigned char* eKeyIv = (unsigned char*)malloc(RSA_size(rsa));
@@ -100,9 +101,11 @@ void lmcCrypto::retreiveAES(QString* lpszUserId, QByteArray& aesKeyIv) {
 
 	int keyLen = 32;
 	EVP_CIPHER_CTX ectx, dctx;
-	EVP_EncryptInit_ex(ectx.ptr(), EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
+	EVP_CIPHER_CTX_init(&ectx);
+	EVP_EncryptInit_ex(&ectx, EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
 	encryptMap.insert(*lpszUserId, ectx);
-	EVP_DecryptInit_ex(dctx.ptr(), EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
+	EVP_CIPHER_CTX_init(&dctx);
+	EVP_DecryptInit_ex(&dctx, EVP_aes_256_cbc(), NULL, keyIv, keyIv + keyLen);
 	decryptMap.insert(*lpszUserId, dctx);
 
 	free(keyIv);
@@ -118,9 +121,9 @@ QByteArray lmcCrypto::encrypt(QString* lpszUserId, QByteArray& clearData) {
 	int foutLen = 0;
 
 	EVP_CIPHER_CTX ctx = encryptMap.value(*lpszUserId);
-	if(EVP_EncryptInit_ex(ctx.ptr(), NULL, NULL, NULL, NULL)) {
-		if(EVP_EncryptUpdate(ctx.ptr(), outBuffer, &outLen, (unsigned char*)clearData.data(), clearData.length())) {
-			if(EVP_EncryptFinal_ex(ctx.ptr(), outBuffer + outLen, &foutLen)) {
+	if(EVP_EncryptInit_ex(&ctx, NULL, NULL, NULL, NULL)) {
+		if(EVP_EncryptUpdate(&ctx, outBuffer, &outLen, (unsigned char*)clearData.data(), clearData.length())) {
+			if(EVP_EncryptFinal_ex(&ctx, outBuffer + outLen, &foutLen)) {
 				outLen += foutLen;
 				QByteArray byteArray((char*)outBuffer, outLen);
 				free(outBuffer);
@@ -142,9 +145,9 @@ QByteArray lmcCrypto::decrypt(QString* lpszUserId, QByteArray& cipherData) {
 	int foutLen = 0;
 
 	EVP_CIPHER_CTX ctx = decryptMap.value(*lpszUserId);
-	if(EVP_DecryptInit_ex(ctx.ptr(), NULL, NULL, NULL, NULL)) {
-		if(EVP_DecryptUpdate(ctx.ptr(), outBuffer, &outLen, (unsigned char*)cipherData.data(), cipherData.length())) {
-			if(EVP_DecryptFinal_ex(ctx.ptr(), outBuffer + outLen, &foutLen)) {
+	if(EVP_DecryptInit_ex(&ctx, NULL, NULL, NULL, NULL)) {
+		if(EVP_DecryptUpdate(&ctx, outBuffer, &outLen, (unsigned char*)cipherData.data(), cipherData.length())) {
+			if(EVP_DecryptFinal_ex(&ctx, outBuffer + outLen, &foutLen)) {
 				outLen += foutLen;
 				QByteArray byteArray((char*)outBuffer, outLen);
 				free(outBuffer);

--- a/lmc/src/crypto.h
+++ b/lmc/src/crypto.h
@@ -1,11 +1,11 @@
 ﻿/****************************************************************************
 **
 ** This file is part of LAN Messenger.
-**
+** 
 ** Copyright (c) 2010 - 2012 Qualia Digital Solutions.
-**
+** 
 ** Contact:  qualiatech@gmail.com
-**
+** 
 ** LAN Messenger is free software: you can redistribute it and/or modify
 ** it under the terms of the GNU General Public License as published by
 ** the Free Software Foundation, either version 3 of the License, or
@@ -31,39 +31,6 @@
 
 #ifndef CRYPTO_H
 #define CRYPTO_H
-
-class EVP_CIPHER_CTX_wrapper {
-public :
-
-	#if OPENSSL_VERSION_NUMBER < 0x10100000L
-
-	EVP_CIPHER_CTX_wrapper() {
-		EVP_CIPHER_CTX_init(&ctx);
-	}
-	EVP_CIPHER_CTX* ptr() { return &ctx; };
-
-	EVP_CIPHER_CTX ctx;
-
-	#else
-
-	EVP_CIPHER_CTX_wrapper() {
-		ctx = EVP_CIPHER_CTX_new();
-		EVP_CIPHER_CTX_init(ctx);
-	}
-
-	~EVP_CIPHER_CTX_wrapper() {
-		EVP_CIPHER_CTX_free(ctx);
-	}
-
-	EVP_CIPHER_CTX* ptr() { return ctx; };
-
-	EVP_CIPHER_CTX* ctx;
-
-	#endif
-
-};
-
-#define EVP_CIPHER_CTX EVP_CIPHER_CTX_wrapper
 
 class lmcCrypto
 {


### PR DESCRIPTION
Reverts lanmessenger/lanmessenger#18

The wrapper though it kind of works, creates new problems like random crashes in windows and even crash on connect in linux. encryptMap and decryptMap should be able to retain a ctx pointer as long as the app is running but when lmcCrypto::generateAES or lmcCrypto::retreiveAES functions finish execution, all objects of class EVP_CIPHER_CTX_wrapper are destroyed calling the destructor of the class which in turn frees the ctx pointer. As long as the pointer isn't overwritten the app seems to work just fine. I have another solution for using openssl 1.1.x in https://github.com/parapente/lanmessenger/commit/cd40f74a463abbf361713c021cb819fcb6a90c46 but it will not compile for openssl versions before v1.1.0.