### PR TITLE
Fix: Add avatar data to sendUserData to enable PFP sharing on Linux

### DIFF
--- a/lmc/src/definitions.h
+++ b/lmc/src/definitions.h
@@ -36,11 +36,11 @@
 #endif
 #define IDA_VERSION		"1.2.39"
 #define IDA_DESCRIPTION	"LAN Messenger is a free peer-to-peer messaging application for intra-network communication "\
-						"and does not require a server.\n"\
-						"LAN Messenger works on essentially every popular desktop platform."
+					"and does not require a server.\n"\
+					"LAN Messenger works on essentially every popular desktop platform."
 #define IDA_COPYRIGHT	"Copyright (C) 2010-2016 Qualia Digital Solutions."
 #define IDA_CONTACT		"lanmsngr@gmail.com"
-#define IDA_DOMAIN		"http://lanmessenger.github.io"
+#define IDA_DOMAIN		"https://github.com/TeamNITE/lanmessenger"
 
 #if defined Q_OS_WIN
 #define IDA_PLATFORM	"Windows"

--- a/lmc/src/messagingproc.cpp
+++ b/lmc/src/messagingproc.cpp
@@ -1,4 +1,4 @@
-﻿/****************************************************************************
+/****************************************************************************
 **
 ** This file is part of LAN Messenger.
 ** 
@@ -155,6 +155,7 @@ void lmcMessaging::sendUserData(MessageType type, QueryOp op, QString* lpszUserI
 	xmlMessage.addData(XN_STATUS, localUser->status);
 	xmlMessage.addData(XN_NOTE, localUser->note);
     xmlMessage.addData(XN_USERCAPS, QString::number(localUser->caps));
+	xmlMessage.addData(XN_AVATAR, QString::number(localUser->avatar));
 	xmlMessage.addData(XN_QUERYOP, QueryOpNames[op]);
 	QString szMessage = Message::addHeader(type, msgId, &localUser->id, lpszUserId, &xmlMessage);
 	pNetwork->sendMessage(lpszUserId, lpszAddress, &szMessage);
@@ -293,7 +294,7 @@ void lmcMessaging::processMessage(MessageHeader* pHeader, XmlMessage* pMessage) 
 			sendUserData(pHeader->type, QO_Result, &pHeader->userId, &pHeader->address);
 		//	add the user only after sending back user data, this way both parties will have added each other
 		addUser(pMessage->data(XN_USERID), pMessage->data(XN_VERSION), pMessage->data(XN_ADDRESS),
-            pMessage->data(XN_NAME), pMessage->data(XN_STATUS), QString::null, pMessage->data(XN_NOTE),
+            pMessage->data(XN_NAME), pMessage->data(XN_STATUS), pMessage->data(XN_AVATAR), pMessage->data(XN_NOTE),
             pMessage->data(XN_USERCAPS));
 		break;
 	case MT_Broadcast:


### PR DESCRIPTION
I have tried to fix the Linux avatar issue. Not tested yet.